### PR TITLE
Add custom entrypoint mapping env vars to cli args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -234,10 +234,8 @@ RUN mv vllm test_docs/
 #################### TEST IMAGE ####################
 
 #################### OPENAI API SERVER ####################
-# openai api server alternative
-
-# define sagemaker first, so it is not default from `docker build`
-FROM vllm-base AS vllm-sagemaker
+# base openai image with additional requirements, for any subsequent openai-style images
+FROM vllm-base AS vllm-openai-base
 
 # install additional dependencies for openai api server
 RUN --mount=type=cache,target=/root/.cache/pip \
@@ -249,11 +247,13 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 ENV VLLM_USAGE_SOURCE production-docker-image
 
-# port 8080 required by sagemaker, https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-inference-code.html#your-algorithms-inference-code-container-response
-ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server", "--port", "8080"]
+# define sagemaker first, so it is not default from `docker build`
+FROM vllm-openai-base AS vllm-sagemaker
 
-# the default image is `vllm-openai` which is identical to sagemaker without forcing the port
-from vllm-sagemaker as vllm-openai
+RUN chmod +x entrypoint.sh
+ENTRYPOINT ["./sagemaker-entrypoint.sh"]
+
+from vllm-openai-base as vllm-openai
 
 ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server"]
 #################### OPENAI API SERVER ####################

--- a/sagemaker-entrypoint.sh
+++ b/sagemaker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Define the prefix for environment variables to look for
+PREFIX="SM_VLLM_"
+ARG_PREFIX="--"
+
+# Initialize an array for storing the arguments
+# port 8080 required by sagemaker, https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-inference-code.html#your-algorithms-inference-code-container-response
+ARGS=(--port 8080)
+
+# Loop through all environment variables
+env | grep "^${PREFIX}" | while IFS='=' read -r key value; do
+    # Remove the prefix from the key, convert to lowercase, and replace underscores with dashes
+    arg_name=$(echo "${key#${PREFIX}}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+
+    # Add the argument name and value to the ARGS array
+    ARGS+=("${ARG_PREFIX}${arg_name}")
+    if [ -n "$value" ]; then
+        ARGS+=("$value")
+    fi
+done
+
+# Pass the collected arguments to the main entrypoint
+exec python3 -m vllm.entrypoints.openai.api_server "${ARGS[@]}"


### PR DESCRIPTION
Cleaned up dockerfile, and parses environment variables with the `SM_VLLM_` (sagemaker vllm) prefix to environment variables.

This is due to the fact that - as far as I know - vLLM does not support passing engine args as environment variables. TGI's flexibility is through using `clap` which allows args to be set either way ([src](https://github.com/huggingface/text-generation-inference/blob/23bc38b10d06f8cc271d086c26270976faf67cc2/backends/v3/src/main.rs#L13)).

Key changes:
* New file - entrypoint for sagemaker with mapping, invoking same api server module
* Slightly restructuring dockerfile to clean up requirements. Adds intermediate `vllm-openai-base` step with the additional pip requirements, which will be required for all openai-style servers. Derives from this for both the `vllm-sagemaker` image and `vllm-base` image